### PR TITLE
Convert Appendix A Tests from Anton’s Haskel Code to Scala

### DIFF
--- a/src/main/scala/org/casualmiracles/finance/contracts/examples/AvSTests.scala
+++ b/src/main/scala/org/casualmiracles/finance/contracts/examples/AvSTests.scala
@@ -1,0 +1,36 @@
+package org.casualmiracles.finance.contracts.examples
+
+import org.casualmiracles.finance.contracts._
+import org.casualmiracles.finance.contracts.examples._
+import Contracts._
+import ExampleModel._
+import Instruments._
+
+// Appendix A Tests from Anton Van Straaten's doco webpage
+object AvSTests extends App{
+
+  
+  val tolerance = 0.001
+  
+  val testK = andPr( liftPr((d:Double)=>d==100, takePr(10, bigK[Double](100))))
+ 
+  val testProb = probabilityLattice(10).sum - 1 < tolerance
+  
+  val xm = exampleModel(mkDate(0))
+  val evalX=evalC(xm,USD)
+
+  val c1:Contract = zeroCouponBond(mkDate(3),10,USD)
+  val pr1 = evalX(c1)
+
+  val testPr1 = andPr(
+   lift2Pr( (a:Double, b:Double) => math.abs(a - b) < tolerance, pr1, PR( Stream[RV[Double]]( 
+      Stream[Double](8.641), 
+      Stream[Double](9.246,8.901),
+      Stream[Double](9.709,9.524,9.346), 
+      Stream[Double](10,10,10,10)
+    ) )
+   )
+  )
+ 
+  assert( List( testK, testProb, testPr1).forall(identity), "Test suite falure")
+}

--- a/src/main/scala/org/casualmiracles/finance/contracts/examples/ExampleModel.scala
+++ b/src/main/scala/org/casualmiracles/finance/contracts/examples/ExampleModel.scala
@@ -25,7 +25,7 @@ object ExampleModel {
 
   def takePr[T](n: Int, pr: PR[T]) = PR(pr.unPr.take(n))
   def horizonPr(pr: PR[_]) = pr.unPr.length
-  def andPr(pr: PR[Boolean]) = pr.unPr.forall _
+  def andPr(pr: PR[Boolean]):Boolean = pr.unPr.forall(rvb => rvb.forall(identity))
 
   case class Model(
     modelStart: Date,
@@ -92,7 +92,7 @@ object ExampleModel {
 
   def expectedValue(outcomes: RV[Double], probabilities: RV[Double]): Double = zipWith(outcomes, probabilities)(_ * _).sum
 
-  def probabiltyLattice: Stream[RV[Double]] = probabilities(pathCounts)
+  def probabilityLattice: Stream[RV[Double]] = probabilities(pathCounts)
 
   def probabilities(s: Stream[RV[Int]]): Stream[RV[Double]] = {
     val (sl #:: sls) = s


### PR DESCRIPTION
1. typo corrected for probabilityLattice method;
2. andPr bug is fixed: originally partially applied function was returned;
3. Haskell tests from AvS webpage are converted.
