### PR TITLE
Adding of alternative Interest Rate Model

### DIFF
--- a/src/main/scala/org/casualmiracles/finance/contracts/PR.scala
+++ b/src/main/scala/org/casualmiracles/finance/contracts/PR.scala
@@ -26,7 +26,10 @@ trait PRs extends Zip {
   def printPr(pr: PR[_], n: Int) = pr.unPr.take(n).zipWithIndex.foreach { is ⇒ { print(is._2 + ": "); printRV(is._1) } }
 
   def printRV(rv: RV[_]) {
-    print(rv.mkString(" "))
+    import java.text.DecimalFormat 
+    val formatter = new DecimalFormat("#.000")
+    
+    print(rv.map( d => String.format("%6s", formatter.format(d)) ).mkString(" "))
     println("")
   }
 }

--- a/src/main/scala/org/casualmiracles/finance/examples/AvSTests.scala
+++ b/src/main/scala/org/casualmiracles/finance/examples/AvSTests.scala
@@ -1,10 +1,12 @@
-package org.casualmiracles.finance.contracts.examples
+package org.casualmiracles.finance.examples
 
 import org.casualmiracles.finance.contracts._
-import org.casualmiracles.finance.contracts.examples._
-import Contracts._
+import org.casualmiracles.finance.models._
+import org.casualmiracles.finance.contracts.Contracts._
 import ExampleModel._
-import Instruments._
+import org.casualmiracles.finance.contracts.Instruments._
+import org.casualmiracles.finance.models._
+import scala.Stream
 
 // Appendix A Tests from Anton Van Straaten's doco webpage
 object AvSTests extends App{
@@ -16,7 +18,7 @@ object AvSTests extends App{
  
   val testProb = probabilityLattice(10).sum - 1 < tolerance
   
-  val xm = exampleModel(mkDate(0))
+  val xm = ExampleModel.makeModel(mkDate(0))
   val evalX=evalC(xm,USD)
 
   val c1:Contract = zeroCouponBond(mkDate(3),10,USD)
@@ -32,5 +34,6 @@ object AvSTests extends App{
    )
   )
  
-  assert( List( testK, testProb, testPr1).forall(identity), "Test suite falure")
+  val testSuite = List( testK, testProb, testPr1)
+  assert( testSuite.forall(identity), "Test suite falure: " + testSuite )
 }

--- a/src/main/scala/org/casualmiracles/finance/examples/Examples.scala
+++ b/src/main/scala/org/casualmiracles/finance/examples/Examples.scala
@@ -1,15 +1,17 @@
-package org.casualmiracles.finance.contracts.examples
+package org.casualmiracles.finance.examples
 
 import org.casualmiracles.finance.contracts._
 import Contracts._
+import Instruments._
+import org.casualmiracles.finance.models._
 import ExampleModel._
 import Cashflows._
-import Instruments._
+import org.casualmiracles.finance.models.Cashflows
 
 object Examples extends App {
 
-  val xm: Model = exampleModel(mkDate(0))
-  val evalX: Contract ⇒ PR[Double] = evalC(xm, USD)
+  val xm: Model = ExampleModel.makeModel(mkDate(0))
+  val evalX: Contract ⇒ PR[Double] = ExampleModel.evalC(xm, USD)
   val t1Horizon = 3
   val t1 = mkDate(t1Horizon)
   val c1: Contract = zeroCouponBond(t1, 10, USD)

--- a/src/main/scala/org/casualmiracles/finance/examples/LatticeModelsFE1Examples.scala
+++ b/src/main/scala/org/casualmiracles/finance/examples/LatticeModelsFE1Examples.scala
@@ -1,0 +1,28 @@
+package org.casualmiracles.finance.examples
+
+// Term Structure Lattice Models base on
+// 2010 Martin Haugh
+// http://www.columbia.edu/~mh2078/LatticeModelsFE1.pdf
+ 
+import org.casualmiracles.finance.contracts._
+import Contracts._
+import Instruments._
+import org.casualmiracles.finance.models._
+import LatticeFE1Model._
+
+object LatticeModelsFE1Examples extends App {
+
+  val ltxm = LatticeFE1Model.makeModel(mkDate(0) )
+  printPr(ltxm.rateModel( USD),6) 
+  
+  val ltevalX=LatticeFE1Model.evalC(ltxm,USD)
+  
+  val ltc1:Contract = zeroCouponBond(mkDate(4),100,USD)
+  val ltpr1 = ltevalX(ltc1)
+  
+  printPr(ltpr1,5) 
+    
+  // TODO: add the rest of the paper securities
+ 
+  //assert( List( testK, testProb, testPr1).forall(identity), "Test suite falure")
+}

--- a/src/main/scala/org/casualmiracles/finance/examples/SwapExperiment.scala
+++ b/src/main/scala/org/casualmiracles/finance/examples/SwapExperiment.scala
@@ -1,11 +1,12 @@
-package org.casualmiracles.finance.contracts.examples
+package org.casualmiracles.finance.examples
 
 import org.casualmiracles.finance.contracts._
 import Contracts._
-
+import org.casualmiracles.finance.models._
 import ExampleModel._
 import Cashflows._
 import Instruments._
+import org.casualmiracles.finance.models.Cashflows
 
 object SwapExperiment extends App {
 
@@ -26,8 +27,8 @@ object SwapExperiment extends App {
  val example = swap(fixedLeg, floatingLeg)
  
  val horizon = 15
- val xm = exampleModel(time0)
- val evalX = evalC(xm, USD)
+ val xm = ExampleModel.makeModel(time0)
+ val evalX = ExampleModel.evalC(xm, USD)
  
  printPr(cashflow(xm, USD, horizon)(example), horizon)
 }

--- a/src/main/scala/org/casualmiracles/finance/models/ArithmeticInterestRateModel.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/ArithmeticInterestRateModel.scala
@@ -1,0 +1,24 @@
+package org.casualmiracles.finance.models
+
+import org.casualmiracles.finance.contracts._
+import Contracts._
+import org.casualmiracles.finance.models._
+import Stream._
+
+trait ArithmeticInterestRateModel extends InterestRateModel {
+  // Arithmetic Interest Rate Model
+  def rates(rateNow: Double, delta: Double): PR[Double] = {
+    def makeRateSlices(rateNow: Double, n: Int): Stream[RV[Double]] = rateSlice(rateNow, n) #:: makeRateSlices(rateNow - delta, n + 1)
+    def rateSlice(minRate: Double, n: Int) = comb(minRate).take(n)
+    def comb(x: Double): Stream[Double] = x #:: comb(x + 2 * delta)
+    PR(makeRateSlices(rateNow, 1))
+  }
+
+  override val rateModels: Map[Currency, PR[Double]] = Map(
+    CHF -> rates(7, 0.8),
+    EUR -> rates(6.5, 0.25),
+    GBP -> rates(8, 0.5),
+    KYD -> rates(11, 1.2),
+    USD -> rates(5, 1),
+    ZAR -> rates(15, 1.5))
+}

--- a/src/main/scala/org/casualmiracles/finance/models/Cashflows.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/Cashflows.scala
@@ -1,13 +1,11 @@
-package org.casualmiracles.finance.contracts.examples
+package org.casualmiracles.finance.models
 
 import org.casualmiracles.finance.contracts._
 import Contracts._
+import scala.Stream
+import scala.collection.immutable.Stream.consWrapper
 
-import Observable._
-import Contract._
-import ExampleModel._
-
-object Cashflows extends Zip {
+object Cashflows extends GenericModel with ArithmeticInterestRateModel{
 
   def cashflow(model: Model, k: Currency, steps: Int): Contract ⇒ PR[Double] = {
     def eval(contract: Contract): PR[Double] = contract match {

--- a/src/main/scala/org/casualmiracles/finance/models/ExampleModel.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/ExampleModel.scala
@@ -1,0 +1,5 @@
+package org.casualmiracles.finance.models
+
+object ExampleModel extends GenericModel with ArithmeticInterestRateModel {
+
+}

--- a/src/main/scala/org/casualmiracles/finance/models/GeometricInterestRateModel.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/GeometricInterestRateModel.scala
@@ -1,0 +1,21 @@
+package org.casualmiracles.finance.models
+
+import org.casualmiracles.finance.contracts._
+import Contracts._
+import Instruments._
+import Stream._
+
+trait GeometricInterestRateModel extends InterestRateModel {
+
+  // Geometric Interest Rate Model
+  def ratesUpDown(rateNow: Double, up: Double, down: Double): PR[Double] = {
+    def makeRateSlices(rateNow: Double, n: Int): Stream[RV[Double]] = rateSlice(rateNow, n) #:: makeRateSlices( rateNow * down, n + 1)
+    def rateSlice(minRate: Double, n: Int) = comb(minRate).take(n)
+    def comb(x:Double): Stream[Double] = x #:: comb(x/down*up)
+    PR(makeRateSlices(rateNow, 1))
+  }
+  
+  override val rateModels: Map[Currency, PR[Double]] = Map(
+    USD -> ratesUpDown(6, 1.25, .9))  
+  
+}

--- a/src/main/scala/org/casualmiracles/finance/models/InterestRateModel.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/InterestRateModel.scala
@@ -1,0 +1,9 @@
+package org.casualmiracles.finance.models
+
+import org.casualmiracles.finance.contracts._
+
+trait InterestRateModel {
+  
+  def rateModels: Map[Currency, PR[Double]]
+  def rateModel(k: Currency): PR[Double] = rateModels.getOrElse(k, sys.error("rateModel: currency not found " + k))
+}

--- a/src/main/scala/org/casualmiracles/finance/models/LatticeModelsFE1Model.scala
+++ b/src/main/scala/org/casualmiracles/finance/models/LatticeModelsFE1Model.scala
@@ -1,0 +1,9 @@
+package org.casualmiracles.finance.models
+
+// Term Structure Lattice Models 
+// 2010 Martin Haugh
+// http://www.columbia.edu/~mh2078/LatticeModelsFE1.pdf
+ 
+object LatticeFE1Model extends GenericModel with GeometricInterestRateModel{
+
+}


### PR DESCRIPTION
The ExampleModel object is refactored, so additional interest rate models can be added. In fact, original rate model is re-branded as an arithmetic one and a new one added wich behaves geometrically.
